### PR TITLE
Ensure growl is 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 
   "dependencies" : {
     "websocket.io": "~0.2",
-    "growl": "*",
+    "growl": "1.7.0",
     "optimist": "~0.3",
     "ws": "~0.4",
     "debug": "~0.6",


### PR DESCRIPTION
The growl node library past 1.6 supports OS X Notifications via the `terminal-notifier` gem.  We should make sure we include the latest version.
