### PR TITLE
Bug 940971 - Tweaks in the growl component r=jlal

### DIFF
--- a/lib/node/server/runner-growl.js
+++ b/lib/node/server/runner-growl.js
@@ -48,8 +48,13 @@ Growl.prototype = {
         reporter = proxy.reporter,
         stats = reporter.stats;
 
+    if (stats.tests === 0) {
+      // don't report anything if there were no tests
+      return;
+    }
+
     if (stats.failures) {
-      var msg = stats.failures + ' of ' + runner.tests + ' tests failed';
+      var msg = stats.failures + ' of ' + stats.tests + ' tests failed';
       notify(msg, { title: 'Failed', image: images.fail });
     } else {
       notify(stats.passes + ' tests passed in ' + stats.duration + 'ms', {


### PR DESCRIPTION
- Fixes the "undefined" message when there are failures
- Don't growl when there are no tests
