### PR TITLE
Bug 957932 - Add coverage execute button for test-agent web interface

### DIFF
--- a/examples/full/test-agent/index.html
+++ b/examples/full/test-agent/index.html
@@ -8,11 +8,17 @@
 </head>
 <body>
 
-<div id="test-agent-search">
-<form>
-  <input type="text" name="search" id="test-agent-search-input" />
-  <button type="button" id="test-agent-search-submit">Search</button>
-</form>
+<div id="test-agent-panel">
+  <form>
+    <input type="text" name="search" id="test-agent-search-input" />
+    <button type="button" id="test-agent-search-submit">Search</button>
+    <div class="options">
+      <label>
+        <input type="checkbox" id="test-agent-coverage-checkbox" />
+        Enable Coverage
+      </label>
+    </div>
+  </form>
 </div>
 
 <!-- Test Agent UI will be loaded in here -->

--- a/lib/test-agent/browser-worker/test-ui.js
+++ b/lib/test-agent/browser-worker/test-ui.js
@@ -49,6 +49,11 @@
     WORKING: 'working',
     EXECUTE: 'execute',
 
+    tasks: {
+      test: 'run tests',
+      coverage: 'run tests with coverage',
+    },
+
     templates: {
       testList: '<ul class="test-list"></ul>',
       testItem: '<li data-url="%s">%s</li>',
@@ -64,10 +69,21 @@
     },
 
     get execButton() {
-      if(!this._execButton){
+      if (!this._execButton) {
         this._execButton = this.element.querySelector('button');
       }
       return this._execButton;
+    },
+
+    get command() {
+      var covCheckbox = document.querySelector('#test-agent-coverage-checkbox'),
+          covFlag = covCheckbox ? covCheckbox.checked : false;
+
+      if (covFlag) {
+        return this.tasks.coverage;
+      } else {
+        return this.tasks.test;
+      }
     },
 
     enhance: function enhance(worker) {
@@ -187,7 +203,7 @@
           }
         }
 
-        self.worker.emit('run tests', {tests: tests});
+        self.worker.emit(self.command, {tests: tests});
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-agent",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "James Lal",
   "description": "execute client side tests from browser report back to cli",
   "main": "lib/node/index.js",

--- a/test-agent.css
+++ b/test-agent.css
@@ -114,7 +114,7 @@ body > iframe {
   text-decoration: none;
 }
 
-#test-agent-search {
+#test-agent-panel {
   position: fixed;
   top: 0;
   left: 0;
@@ -124,6 +124,11 @@ body > iframe {
   width: 100%;
   height: 4.5rem;
   z-index: 4;
+}
+
+#test-agent-panel .options {
+  margin-top: 0.2rem;
+  margin-left: -0.3rem;
 }
 
 @media only screen and (max-width: 480px) {
@@ -141,7 +146,7 @@ body > iframe {
     top: .8rem;
   }
 
-  #test-agent-search {
+  #test-agent-panel {
     padding: 1rem;
     border-bottom: 1px solid #aaa;
   }

--- a/test-agent.js
+++ b/test-agent.js
@@ -3250,6 +3250,11 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     WORKING: 'working',
     EXECUTE: 'execute',
 
+    tasks: {
+      test: 'run tests',
+      coverage: 'run tests with coverage',
+    },
+
     templates: {
       testList: '<ul class="test-list"></ul>',
       testItem: '<li data-url="%s">%s</li>',
@@ -3265,10 +3270,21 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     },
 
     get execButton() {
-      if(!this._execButton){
+      if (!this._execButton) {
         this._execButton = this.element.querySelector('button');
       }
       return this._execButton;
+    },
+
+    get command() {
+      var covCheckbox = document.querySelector('#test-agent-coverage-checkbox'),
+          covFlag = covCheckbox ? covCheckbox.checked : false;
+
+      if (covFlag) {
+        return this.tasks.coverage;
+      } else {
+        return this.tasks.test;
+      }
     },
 
     enhance: function enhance(worker) {
@@ -3350,6 +3366,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       this.element.appendChild(fragment(templates.testRun));
 
       this.initDomEvents();
+      window.dispatchEvent(new CustomEvent('test-agent-list-done'));
     },
 
     initDomEvents: function initDomEvents() {
@@ -3387,7 +3404,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
           }
         }
 
-        self.worker.emit('run tests', {tests: tests});
+        self.worker.emit(self.command, {tests: tests});
       });
     }
 

--- a/test-agent/index.html
+++ b/test-agent/index.html
@@ -9,11 +9,17 @@
 </head>
 <body>
 
-<div id="test-agent-search">
-<form>
-  <input type="text" name="search" id="test-agent-search-input" />
-  <button type="button" id="test-agent-search-submit">Search</button>
-</form>
+<div id="test-agent-panel">
+  <form>
+    <input type="text" name="search" id="test-agent-search-input" />
+    <button type="button" id="test-agent-search-submit">Search</button>
+    <div class="options">
+      <label>
+        <input type="checkbox" id="test-agent-coverage-checkbox" />
+        Enable Coverage
+      </label>
+    </div>
+  </form>
 </div>
 
 <div id="test-agent-ui">


### PR DESCRIPTION
Enable coverage only can execute from command line interface is inconvenient for testing specified unit tests. So add a coverage button and let people can execute unit tests they want is a good way.
