### PR TITLE
Bug 892048 - [test-agent] The test agent hangs when 1 test run is asked ...

### DIFF
--- a/lib/node/server/watcher.js
+++ b/lib/node/server/watcher.js
@@ -15,14 +15,17 @@ Watcher.prototype = {
 
   basePath: '/',
   eventName: 'queue tests',
+  MAX_BATCH_LENGTH: 5,
+  _currentBatch: [],
+  _batchTimeout: null,
 
   enhance: function enhance(server) {
-    this.suite = server.suite;
-    this.start(this._onFileChange.bind(this, server));
+    this.server = server;
+    this.start(this._onFileChange.bind(this));
   },
 
   start: function start(callback) {
-    this.suite.findFiles(function(err, files) {
+    this.server.suite.findFiles(function(err, files) {
       if (err) {
         throw err;
       }
@@ -31,10 +34,30 @@ Watcher.prototype = {
     });
   },
 
-  _onFileChange: function _onFileChange(server, file) {
-    server.emit(this.eventName, {files: [file]});
-  }
+  _onFileChange: function _onFileChange(file) {
+    // we try to batch the file changes in one request
+    if (this._currentBatch.indexOf(file) !== -1) {
+      return;
+    }
 
+    this._currentBatch.push(file);
+    clearTimeout(this._batchTimeout);
+    this._batchTimeout = setTimeout(this._sendBatchRequest.bind(this), 1000);
+  },
+
+  _sendBatchRequest: function _sendBatchRequest() {
+    // trying to prevent running loads of tests when changing branches
+    if (this._currentBatch.length <= this.MAX_BATCH_LENGTH) {
+      this.server.emit(this.eventName, {files: this._currentBatch});
+    } else {
+      console.warn('Too many files changed at once (' +
+                   this._currentBatch.length,
+                   'changed files), so skipping this batch.');
+    }
+
+    this._currentBatch = [];
+    this._batchTimeout = null;
+  }
 };
 
 module.exports = exports = Watcher;

--- a/lib/node/watchr.js
+++ b/lib/node/watchr.js
@@ -19,7 +19,7 @@ Watchr.prototype = {
 
 
     this.files.forEach(function(file) {
-      var result = fs.watchFile(file, {interval: 100}, function(curr, prev) {
+      var result = fs.watchFile(file, {interval: 200}, function(curr, prev) {
         if (curr.mtime > prev.mtime) {
           callback(file);
         }

--- a/lib/test-agent/browser-worker.js
+++ b/lib/test-agent/browser-worker.js
@@ -5,6 +5,7 @@
     window.TestAgent = {};
   }
 
+  /* BrowserWorker is the Worker that runs inside an iframe */
   TestAgent.BrowserWorker = function BrowserWorker(options) {
     var self = this,
         dep = this.deps;

--- a/lib/test-agent/browser-worker/multi-domain-driver.js
+++ b/lib/test-agent/browser-worker/multi-domain-driver.js
@@ -1,4 +1,8 @@
 (function(window) {
+  'use strict';
+
+  // This Driver is used in the main Test-Agent window, to manage the iframes
+  // sandboxes for each domain
 
   function Driver(options) {
     var key;
@@ -8,6 +12,7 @@
 
     this.testGroups = {};
     this.sandboxes = {};
+    this._batches = [];
 
     for (key in options) {
       if (options.hasOwnProperty(key)) {
@@ -42,9 +47,7 @@
         }
       });
 
-      worker.on('run tests complete', function() {
-        self._loadNextDomain();
-      });
+      worker.on('run tests complete', this._next.bind(this));
 
       worker.runTests = this.runTests.bind(this);
 
@@ -149,15 +152,18 @@
       } else {
         this.currentEnv = null;
       }
+
+      return (this.currentEnv !== null);
     },
 
     /**
      * Sends run tests event to domain.
+     * This send the "run tests" event to the iframe sandbox
      *
      * @param {String} env the enviroment to test against.
      */
     _startDomainTests: function(env) {
-      var iframe, tests, group;
+      var iframe, group;
 
       if (env in this.sandboxes) {
         iframe = this.sandboxes[env];
@@ -201,21 +207,67 @@
       }
     },
 
+    _isBatchScheduled: function(newBatch) {
+      return this._batches.some(function(existingBatch) {
+        return (newBatch.runCoverage === existingBatch.runCoverage) &&
+          existingBatch.tests.every(function(test, i) {
+            return test === newBatch.tests[i];
+          });
+      });
+    },
+
     /**
      * Runs a group of tests.
      *
      * @param {Array} tests list of tests to run.
      */
     runTests: function(tests, runCoverage) {
+      var batch = {
+        tests: tests,
+        runCoverage: runCoverage
+      };
+
+      if (this._isBatchScheduled(batch)) {
+        return;
+      }
+
+      this._batches.push(batch);
+
+      if (!this._running) {
+        this._next();
+      }
+    },
+
+    _loadNextBatch: function() {
+      var batch = this._batches.shift();
+      if (!batch) {
+        return false;
+      }
+
       var envs;
-      this.runCoverage = runCoverage;
-      this._createTestGroups(tests);
+      this.runCoverage = batch.runCoverage;
+      this._createTestGroups(batch.tests);
       envs = Object.keys(this.testGroups);
+
+      // when the env is ready, we'll get a 'worker start' event to actually
+      // starts the tests
       this.worker.emit('set test envs', envs);
       this.worker.send('set test envs', envs);
-      this._loadNextDomain();
-    }
 
+      this._next();
+
+      return true;
+    },
+
+    // Runs the next domain, or the next batch if there is no any domain.
+    // This also resets the running flag if there is nothing left to run.
+    _next: function() {
+      this._running = true;
+
+      if (!this._loadNextDomain() && !this._loadNextBatch()) {
+        this._running = false;
+      }
+    }
   };
 
   window.TestAgent.BrowserWorker.MultiDomainDriver = Driver;

--- a/lib/test-agent/mocha/reporter.js
+++ b/lib/test-agent/mocha/reporter.js
@@ -135,6 +135,12 @@
     if (data.event === 'start' && !this.proxy) {
       this.createRunner();
     }
+
+    if (!this.proxy) {
+      // ignore events until next start
+      return null;
+    }
+
     return this.proxy.respond([data.event, data.data]);
   };
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "node-static": "~0.5"
   },
   "devDependencies": {
-    "expect.js": "~0.1",
-    "mocha": "~1.7"
+    "expect.js": "~0.2",
+    "mocha": "~1.17",
+    "sinon": "~1.8"
   },
 
   "license": "MIT",

--- a/test/test-agent/mocha/reporter-test.js
+++ b/test/test-agent/mocha/reporter-test.js
@@ -149,7 +149,8 @@ describe('node/mocha/reporter', function() {
         origRespond,
         sentStartEvent = false,
         endData = ['end', {}],
-        startData = ['start', {total: 20}];
+        startData = ['start', {total: 20}],
+        someData = ['test data', {}];
 
     before(function() {
       origRespond = Proxy.prototype.respond;
@@ -236,6 +237,14 @@ describe('node/mocha/reporter', function() {
         });
       });
 
+    });
+
+    describe('when receiving something before a start', function() {
+      // this can happens when we launch a test run while another run is running
+
+      it('should not choke', function() {
+        subject.respond(someData);
+      });
     });
   });
 


### PR DESCRIPTION
...but another is already running r=jlal
- increase the file watcher poll delay to reduce the CPU consumption. Eventually
  we'll want to use a inotify-based mechanism instead of the polling mechanism.
- batch file watcher results so that we can cancel it when we have too many
  modifications at once, especially when riding git branches
- properly queue new batch requests when one request is already happening
- don't schedule already existing requests
- upgrade mocha so that it doesn't think iframes are leaking globals
